### PR TITLE
Also search for /usr/bin/editor

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -26,6 +26,7 @@ class EditorError(RuntimeError):
 def get_default_editors():
     # TODO: Make platform-specific
     return [
+        'editor',
         'vim',
         'emacs',
         'nano',


### PR DESCRIPTION
To conform to the Debian policy manual, and fix the bug at:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=802232
this patch searches first for /usr/bin/editor.