### PR TITLE
test.py: decode cont before writing it to stdout

### DIFF
--- a/test.py
+++ b/test.py
@@ -3,4 +3,4 @@ import editor
 
 cont = editor.edit(contents='ABC!',
                    use_tty='use_tty' in sys.argv)
-sys.stdout.write(cont)
+sys.stdout.write(cont.decode())


### PR DESCRIPTION
Fixed python3 error:
TypeError: write() argument must be str, not bytes