### PR TITLE
support python 3.12

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -62,7 +62,10 @@ def get_editor():
     # the user explicitly apt-get install python3-distutils. With the
     # import here it will only break if the code is utilizing the
     # inquirer editor prompt.
-    from distutils.spawn import find_executable
+    try:
+        from distutils.spawn import find_executable
+    except ImportError:
+        from shutil import which as find_executable
 
     # Get the editor from the environment.  Prefer VISUAL to EDITOR
     editor = os.environ.get('VISUAL') or os.environ.get('EDITOR')


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed

Fixes #35
Fixes #29
